### PR TITLE
🚑 Hotfix : API 클라이언트가 첫번째 페이지의 내용만을 읽어들이는 버그 수정

### DIFF
--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -64,8 +64,8 @@ function useInfiniteQueryForFandomKAPI({
         }),
         initialPageParam: 0,
         // eslint-disable-next-line
-        getNextPageParam: (_lastPage, _allPages, lastPageParam, _allPageParams) =>
-            lastPageParam,
+        getNextPageParam: (lastPage, _allPages, _lastPageParam, _allPageParams) =>
+            lastPage.nextCursor,
     });
 
     return {


### PR DESCRIPTION
## 🧩 연관된 이슈

#14 

## ✅ 작업 내용

- [x] API 클라이언트가 첫번째 페이지의 내용만을 읽어들이는 버그 수정

## 👩‍💻 공유 포인트 및 논의 사항

잘못된 커밋으로 불편을 끼쳐서 죄송합니다.
