### PR TITLE
✨ feat: API클라이언트 기능 보강 (#14)

### DIFF
--- a/src/api/charts/getCharts.js
+++ b/src/api/charts/getCharts.js
@@ -1,17 +1,12 @@
 import axios from '../axios';
 
-async function getCharts({ gender, nextDataSize, cursor }) {
-    const res = await axios.get('/charts/{gender}', {
+const getCharts = ({ gender, cursor }, pageSizeCallback) => axios.get('/charts/{gender}', {
         params: {
             gender,
             cursor,
-            pageSize: nextDataSize,
+            pageSize: pageSizeCallback()
         },
-    });
-
-    const charts = res.data;
-
-    return charts;
-}
+    }
+).then(res => res.data);
 
 export default getCharts;

--- a/src/api/charts/useChartQuery.js
+++ b/src/api/charts/useChartQuery.js
@@ -1,14 +1,15 @@
-import { useInfiniteQueryForFandomKAPI } from '../hooks';
-import { SERVER_STATE_KEYS } from '../config';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import getCharts from './getCharts';
+import { reduceMultiPageDataWithListName, getNextPageParam } from '../utils';
+import { QUERY_KEYS } from '../config';
 
-function useChartQuery(gender = 'female') {
-    return useInfiniteQueryForFandomKAPI({
-        serverStateKey: SERVER_STATE_KEYS[`${gender}Chart`],
-        queryArguments: { gender },
-        pageName: 'idols',
-        queryFunction: getCharts,
-    });
-}
+const useChartQuery = (chartName = 'female', pageSizeCallback = () => 10) => useInfiniteQuery({
+        queryKey: QUERY_KEYS[`${chartName}Chart`],
+        queryFn: ({queryKey, pageParam: cursor}) => getCharts({ gender: queryKey[0], cursor }, pageSizeCallback),
+        select: (multiPageData) => reduceMultiPageDataWithListName(multiPageData, 'idols'),
+        initialPageParam: 0,
+        getNextPageParam,
+    }
+);
 
 export default useChartQuery;

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -6,14 +6,16 @@ const CLIENT_STATE_KEYS = {
 const ENV = {
   serverUrl: 'https://fandom-k-api.vercel.app',
   teamName: '6-9',
-  pageSize: 10,
+  defaultPageSize: 10,
 };
 
-const SERVER_STATE_KEYS = {
-  femaleChart: 'female',
-  maleChart: 'male',
-  donation: 'donation',
-  idol: 'idol',
+const QUERY_KEYS = {
+  femaleChart: ['female'],
+  maleChart: ['male'],
+  femaleMonthChart: ['female', 'month'],
+  maleMonthChart: ['male', 'month'],
+  donations: ['donations'],
+  idols: ['idols'],
 };
 
-export { CLIENT_STATE_KEYS, ENV, SERVER_STATE_KEYS };
+export { CLIENT_STATE_KEYS, ENV, QUERY_KEYS };

--- a/src/api/donations/getDonations.js
+++ b/src/api/donations/getDonations.js
@@ -1,17 +1,11 @@
 import axios from '../axios';
 
-async function getDonations({ cursor, nextDataLength }) {
-
-    const res = await axios.get('/donations', {
+const getDonations = ({ cursor }, pageSizeCallback) => axios.get('/donations', {
         params: {
             cursor,
-            pageSize: nextDataLength
+            pageSize: pageSizeCallback(),
         },
-    });
-
-    const donations = res.data;
-
-    return donations;
-}
+    }
+).then(res => res.data);
 
 export default getDonations;

--- a/src/api/donations/putContribute.js
+++ b/src/api/donations/putContribute.js
@@ -1,15 +1,9 @@
 import axios from '../axios';
 
-async function putContribute(donationId, creditsToDonate) {
-    const res = await axios.put(
+const putContribute = (donationId, creditsToDonate) => axios.put(
         `/donations/${donationId}/contribute`, {
             amount: creditsToDonate,
         }
-    );
-
-    const donation = res.data;
-
-    return donation;
-}
+    ).then(res => res.data);
 
 export default putContribute;

--- a/src/api/donations/useDonationMutation.js
+++ b/src/api/donations/useDonationMutation.js
@@ -1,15 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import putContribute from './putContribute';
-import { SERVER_STATE_KEYS } from '../config';
+import { QUERY_KEYS } from '../config';
 
-function useDonationMutation() {
+const useDonationMutation = () => {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: ({ donationId, creditsToDonate }) =>
             putContribute(donationId, creditsToDonate),
         onSuccess: () =>
-            queryClient.invalidateQueries(SERVER_STATE_KEYS.donation),
+            queryClient.invalidateQueries({ queryKey: QUERY_KEYS.donations }),
     });
 }
 

--- a/src/api/donations/useDonationQuery.js
+++ b/src/api/donations/useDonationQuery.js
@@ -1,11 +1,15 @@
-import { useInfiniteQueryForFandomKAPI } from '../hooks';
-import { SERVER_STATE_KEYS } from '../config';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { reduceMultiPageDataWithListName, getNextPageParam } from '../utils';
 import getDonations from './getDonations';
+import { QUERY_KEYS } from '../config';
 
-function useDonationQuery() {
-    return useInfiniteQueryForFandomKAPI({
-        serverStateKey: SERVER_STATE_KEYS.donation,
-        queryFunction: getDonations,
-    });
-}
+const useDonationQuery = (pageSizeCallback = () => 10) => useInfiniteQuery({
+        queryKey: QUERY_KEYS.donations,
+        queryFn: ({ queryKey, pageParam }) => getDonations({ queryKey, cursor: pageParam }, pageSizeCallback),
+        select: (multiPageData) => reduceMultiPageDataWithListName(multiPageData, 'list'),
+        initialPageParam: 0,
+        getNextPageParam,
+    }
+);
+
 export default useDonationQuery;

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -64,8 +64,8 @@ function useInfiniteQueryForFandomKAPI({
         }),
         initialPageParam: 0,
         // eslint-disable-next-line
-        getNextPageParam: (_lastPage, _allPages, lastPageParam, _allPageParams) =>
-            lastPageParam,
+        getNextPageParam: (lastPage, _allPages, _lastPageParam, _allPageParams) =>
+            lastPage.nextCursor,
     });
 
     return {

--- a/src/api/idols/getIdols.js
+++ b/src/api/idols/getIdols.js
@@ -1,17 +1,11 @@
 import axios from '../axios';
 
-async function getIdols({ cursor, nextDataLength, keyword = '' }) {
-    const res = await axios.get('/idols', {
+const getIdols = ({ cursor }, pageSizeCallback = () => 9999) => axios.get('/idols', {
         params: {
             cursor,
-            keyword,
-            pageSize: nextDataLength
+            pageSize: pageSizeCallback(),
         },
-    });
- 
-    const idols = res.data;
-
-    return idols;
-}
+    }
+).then(res => res.data);
 
 export default getIdols;

--- a/src/api/idols/useIdolsQuery.js
+++ b/src/api/idols/useIdolsQuery.js
@@ -1,11 +1,14 @@
-import { useInfiniteQueryForFandomKAPI } from '../hooks';
-import { SERVER_STATE_KEYS } from '../config';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { reduceMultiPageDataWithListName, getNextPageParam } from '../utils';
 import getIdols from './getIdols';
+import { QUERY_KEYS } from '../config';
 
-function useIdolsQuery() {
-    return useInfiniteQueryForFandomKAPI({
-        serverStateKey: SERVER_STATE_KEYS.idol,
-        queryFunction: getIdols,
-    });
-}
+const useIdolsQuery = (pageSizeCallback = () => 10) => useInfiniteQuery({
+        queryKey: QUERY_KEYS.idols,
+        queryFn: ({ queryKey, pageParam }) => getIdols({ queryKey, cursor: pageParam }, pageSizeCallback),
+        select: (multiPageData) => reduceMultiPageDataWithListName(multiPageData, 'list'),
+        initialPageParam: 0,
+        getNextPageParam,
+    })
+
 export default useIdolsQuery;

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,0 +1,23 @@
+const reduceAllPagesWithListName = (pages, listName) => 
+    pages.reduce((accumulator, currentValue) => [...accumulator, ...currentValue[listName]], []);
+
+const reduceAllPageParams = (pageParams) => [pageParams[pageParams.length - 1]];
+
+const reduceMultiPageDataWithListName = (multiPageData, listName) => ({
+    pages: reduceAllPagesWithListName(multiPageData.pages, listName),
+    pageParams: reduceAllPageParams(multiPageData.pageParams),
+});
+
+const reduceMultiPageData = (multiPageData) => reduceMultiPageDataWithListName(multiPageData, 'list');
+
+const requestNextPage = async ({ hasNextPage, isFetching, fetchNextPage }) => {
+    if(hasNextPage && !isFetching) {
+        await fetchNextPage();
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getNextPageParam = (lastPage, _allPages, _lastPageParam, _allPageParams) =>
+    lastPage.nextCursor;
+
+export { requestNextPage, reduceMultiPageDataWithListName, reduceMultiPageData, getNextPageParam };

--- a/src/api/votes/postVote.js
+++ b/src/api/votes/postVote.js
@@ -1,13 +1,9 @@
 import axios from '../axios';
 
-async function postVote(idolId) {
-    const res = await axios.post(
+const postVote = (idolId) => axios.post(
         '/votes', {
             idolId,
-        });
-
-    const vote = res.data;
-    return vote;
-}
+        }
+    ).then(res => res.data)
 
 export default postVote;

--- a/src/api/votes/useVoteMutation.js
+++ b/src/api/votes/useVoteMutation.js
@@ -1,16 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { SERVER_STATE_KEYS } from '../config';
+import { QUERY_KEYS } from '../config';
 import postVote from './postVote';
 
-function useVoteMutation() {
+const useVoteMutation = () => {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: (idolId) => postVote(idolId),
-        onSuccess: () => Promise.all([
-            queryClient.invalidateQueries(SERVER_STATE_KEYS.femaleChart),
-            queryClient.invalidateQueries(SERVER_STATE_KEYS.maleChart),
-        ])
+        onSuccess: () => Promise.all(
+            ['maleChart', 'femaleChart', 'maleMonthChart', 'femaleMonthChart'].map(
+                (chart) => { console.log(chart);
+                    return queryClient.invalidateQueries({ queryKey: QUERY_KEYS[chart]})
+                }
+            )
+        )
     });
 }
 

--- a/src/components/Modal/VoteModalBody.jsx
+++ b/src/components/Modal/VoteModalBody.jsx
@@ -63,7 +63,7 @@ const VoteModalBody = ({ type }) => {
 
   const [credit, chargeCredit, payCredit] = useCredits();
   const { mutate: vote } = useVoteMutation();
-  const { data, fetchNextPage, hasNextPage } = useChartQuery(type);
+  const { data, fetchNextPage, hasNextPage } = useChartQuery(`${type}Month`);
 
   const handleSelected = (id) => {
     setChecked(id);
@@ -76,7 +76,6 @@ const VoteModalBody = ({ type }) => {
 
   const renderVoteOption = () => {
     return data?.pages
-      .flatMap((page) => page.idols)
       .sort((a, b) => b.totalVotes - a.totalVotes)
       .map((idol) => (
         <VoteOption

--- a/src/pages/ListPage/ChartSection.jsx
+++ b/src/pages/ListPage/ChartSection.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import ModalComponent from '../../components/Modal/ModalComponent';
 import useChartQuery from '../../api/charts/useChartQuery';
@@ -7,50 +7,33 @@ import Typography from '../../components/Typography';
 import classes from './ChartSection.module.css';
 import Buttons from '../../components/Buttons';
 
+const setPageSizeBasedOnWidth = () => {
+  const isWidthLargerThan1280px = window.matchMedia('(min-width: 1280px)').matches
+  return isWidthLargerThan1280px ? 10 : 5;
+};
+
 function ChartSection() {
   const [opened, { open, close }] = useDisclosure(false);
   const menuArr = ['이달의 여자 아이돌', '이달의 남자 아이돌'];
   const [activeTab, setActiveTab] = useState(0);
-  const [page, setPage] = useState(0);
-  const [itemsPerPage, setItemsPerPage] = useState(0);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setItemsPerPage(window.innerWidth < 1280 ? 5 : 10);
-      setPage(0);
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
 
   const { data, fetchNextPage, hasNextPage } = useChartQuery(
-    activeTab === 0 ? 'female' : 'male',
-    { initialPage: page, pageSize: itemsPerPage },
+    activeTab === 0 ? 'female' : 'male', setPageSizeBasedOnWidth
   );
 
   const handleTabClick = (index) => {
     setActiveTab(index);
-    setPage(0);
   };
 
   const loadMoreIdols = () => {
-    fetchNextPage(page + 1);
-    setPage(page + 1);
+    fetchNextPage();
   };
 
-  const renderChartCards = () => {
-    return data?.pages
-      .flatMap((page) => page.idols)
+  const renderChartCards = () => data?.pages
       .sort((a, b) => b.totalVotes - a.totalVotes)
       .map((idol, index) => (
         <ChartCard key={idol.id} idol={idol} rank={index + 1} />
       ));
-  };
 
   return (
     <div className={classes.chartSection}>

--- a/src/pages/my-page/MyPage.jsx
+++ b/src/pages/my-page/MyPage.jsx
@@ -1,14 +1,11 @@
-import classes from './MyPage.module.css';
-
 import { useEffect, useState } from 'react';
-
-import useIdolsQuery from '../../api/idols/useIdolsQuery';
+import classes from './MyPage.module.css';
 import useFavoriteIdols from '../../api/favoriteIdols/useFavoriteIdols';
+import getIdols from '../../api/idols/getIdols';
 
 import RoundCardWithText from './components/RoundCardWithText';
 import Container from './components/Container.jsx';
 import Buttons from '../../components/Buttons';
-import NotFound from '../NotFound';
 import FavoriteRoundCard from './components/FavoriteRoundCard';
 import EmptyFavoriteIdols from './components/EmptyFavoriteIdols';
 
@@ -26,15 +23,46 @@ const getPageSize = () => {
 };
 
 const MyPage = () => {
-  const [favoriteIdols, unUseFunction, addFavoriteIdol, removeFavoriteIdol] =
-    useFavoriteIdols();
-
-  const { data, error, isLoading, isError } = useIdolsQuery();
   const [idolData, setIdolData] = useState([]);
   const [checkedFavoriteId, setCheckedFavoriteId] = useState([]);
   const [selectableIdols, setSelectableIdols] = useState([]);
   const [currentPage, setCurrentPage] = useState(0);
   const [pageSize, setPageSize] = useState(getPageSize());
+  const [isLoading, setIsLoading] = useState(false);
+
+  // LocalStorage
+  const [favoriteIdols, unUseFunction, addFavoriteIdol, removeFavoriteIdol] =
+    useFavoriteIdols();
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      setPageSize(getPageSize);
+    });
+
+    const getData = async () => {
+      setIsLoading(true);
+      const { list } = await getIdols({ cursor: 0 }, () => 9999);
+      setIdolData(list);
+      setIsLoading(false);
+    };
+    
+    getData();
+
+    return () => {
+      window.removeEventListener('resize', () => {
+        setPageSize(getPageSize);
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    if (idolData?.length > 0) {
+      const selectableData = idolData.filter(
+        (idol) => !favoriteIdols.includes(idol.id),
+      );
+      setSelectableIdols(selectableData);
+    }
+  }, [idolData, favoriteIdols]);
 
   const handleFavoriteList = (idolId) => {
     if (checkedFavoriteId.includes(idolId)) {
@@ -57,40 +85,6 @@ const MyPage = () => {
   const handlePrevPage = () => {
     setCurrentPage((prevPage) => Math.max(prevPage - 1, 0));
   };
-
-  useEffect(() => {
-    window.addEventListener('resize', () => {
-      setPageSize(getPageSize);
-    });
-
-    return () => {
-      window.removeEventListener('resize', () => {
-        setPageSize(getPageSize);
-      });
-    };
-  }, []);
-
-  useEffect(() => {
-    setIdolData(data?.pages[0].list);
-    console.log(idolData);
-  }, [data]);
-
-  useEffect(() => {
-    if (idolData?.length > 0) {
-      const selectableData = idolData.filter(
-        (idol) => !favoriteIdols.includes(idol.id),
-      );
-      setSelectableIdols(selectableData);
-    }
-  }, [idolData, favoriteIdols]);
-
-  if (isLoading) {
-    return <>Loading</>;
-  }
-  if (isError) {
-    console.error(error);
-    return <NotFound errorMessage={'오류가 발생하였습니다.'} />;
-  }
 
   return (
     <div className={classes.MyPage}>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,4 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/frontend',
 });


### PR DESCRIPTION
## 🧩 연관된 이슈

#14

## ✅ 작업 내용

- [ ] 캐러셀에 필요한 모금 자료에서,  기한이 지났거나 완료된 모금을 제외하기 (구현이 어렵지 않으나, 나중에 진행하기로 담당자와 합의함)
- [x] 이달의 차트 섹션에서 화면의 크기에 따라 다른 양의 데이터를 가져오기  (ChartSection.jsx: line 10, 20 참조)
- [x] API클라이언트에서 이달의 차트 섹션과, 아이돌 투표 모달의 데이터 관리를 분리함(독립된 쿼리 키를 도입하여). (ChartSection.jsx: line 20, VoteModalBody: line 66 참조)
- [x] 서버에 수정 요청을 날릴 때마다 변경될 가능성이 있는 데이터를 업데이트해야 하나, 그렇지 못한 버그 수정 (useDonationMutation.js, useVoteMutation.js의 queryClient.invalidateQueries 함수의 변경사항 참조)

## 👩‍💻 공유 포인트 및 논의 사항

여러분들께 참고 목적으로 제가 수정한 예시를 커밋에 추가하였습니다. 다만에, 메인 브랜치에 머지하실때에는 팀원 여러분의 구현이 우선으로 반영되어야 하는 만큼, API 이외의 수정은 반영하지 않으시면 좋겠습니다. 만약 저의 수정이 타당하거나 그렇지 않다고 여기신다면, 댓글로 남겨주십시요.