### PR TITLE
🚑 Hotfix: 99번 PR에서 누락된 주소 변경 로직 반영(#44)

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,28 @@
     <title>FANDOM-K</title>
     <link rel="icon" href="./src/assets/favicon.png" />
     <link rel="stylesheet" href="./index.css" />
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 🧩 연관된 이슈

#44 

## ✅ 작업 내용

- [x] 404.html의 도입으로 정적사이트를 호스팅하는 깃허브 페이지에서 인식할 수 없는 페이지 주소를 쿼리 문자열에 담아서 인덱스 페이지로 리다이렉트함.
- [x] index.html은 자신의 주소에 404.html에서 보낸 쿼리 문자열이 있는 경우 서버에 해당페이지를 요청하지 않고 로컬에서 페이지 주소를 변경하여 해당 페이지가 바로 노출되도록 함.

## 👩‍💻 공유 포인트 및 논의 사항
